### PR TITLE
fix(ranking): Update first solve on ranking upload

### DIFF
--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -156,6 +156,7 @@
                         url: '?raw'
                     }).done(function (data) {
                         $('#users-table').html(data);
+                        firstSolve();
                     }).always(function () {
                         ranking_outdated = false;
                         setTimeout(update_ranking, 10000);
@@ -236,7 +237,7 @@
                 return sub1['time'] < sub2['time'];
             }
 
-            function firstSolve() {
+            window.firstSolve = function() {
                 let firstSolves = {};
 
                 $('td.full-score a').each(function () {


### PR DESCRIPTION
# Description
Type of change: bug fix?

## What

Calls `firstSolve` when `update_ranking` succeeds.
This fixes the issue in ranking.html where the first solve highlight is lost after 10 seconds if the contest has not ended.

Sửa được lỗi mất highlight sau 10 giây nếu kỳ thi đang diễn ra.

## Why

Fixes an internal issue.

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
