### PR TITLE
fix(ranking): Refresh personal info on update.

### DIFF
--- a/templates/contest/ranking.html
+++ b/templates/contest/ranking.html
@@ -156,7 +156,9 @@
                         url: '?raw'
                     }).done(function (data) {
                         $('#users-table').html(data);
-                        firstSolve();
+                        for (let callback of window.ranking_updated_callbacks || []) {
+                            callback();
+                        }
                     }).always(function () {
                         ranking_outdated = false;
                         setTimeout(update_ranking, 10000);
@@ -205,10 +207,17 @@
                 localStorage.setItem('show-personal-info', $('.personal-info').is(':visible') ? 'true' : 'false');
             });
 
-            if (localStorage.getItem('show-personal-info') == 'true') {
-                $('.personal-info').show();
-                $('#show-personal-info-checkbox').prop('checked', true);
+            function setupPersonalInfo() {
+                if (localStorage.getItem('show-personal-info') == 'true') {
+                    $('.personal-info').show();
+                    $('#show-personal-info-checkbox').prop('checked', true);
+                }
             }
+            
+            window.ranking_updated_callbacks = window.ranking_updated_callbacks || [];
+            ranking_updated_callbacks.push(setupPersonalInfo);
+            
+            setupPersonalInfo();
 
             var contest_key = '{{contest.key}}';
 
@@ -237,7 +246,7 @@
                 return sub1['time'] < sub2['time'];
             }
 
-            window.firstSolve = function() {
+            function firstSolve() {
                 let firstSolves = {};
 
                 $('td.full-score a').each(function () {
@@ -271,6 +280,8 @@
                 }
             }
 
+            window.ranking_updated_callbacks = window.ranking_updated_callbacks || [];
+            ranking_updated_callbacks.push(firstSolve);
             
             firstSolve();
 


### PR DESCRIPTION
# Description

Refresh personal info on update.

Type of change: bug fix

## What

Refresh the `.personal-info` CSS class similar to the fix for the previous `firstSolve` issue.
See this [video](https://cdn.discordapp.com/attachments/957289878582866032/982603345623646258/chrome_dNXQyGBxLG.mp4?size=4096) for the issue.


## Why

Improve user experience.

Fixes internal issue.

# How Has This Been Tested?

# Checklist

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
